### PR TITLE
Added UnchangeableNationalIdentificationNumber

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -66,7 +66,8 @@ export const selectAccount: MethodInterface = {
         'TemplateURL',
         'URLTarget',
         'RequestDirectDebitMandate',
-        'Email'
+        'Email',
+        'UnchangeableNationalIdentificationNumber'
     ],
     requiredFields: ['NotificationURL', 'EndUserID', 'MessageID']
 }


### PR DESCRIPTION
For Swedish banks UnchangeableNationalIdentificationNumber will enable user to not change their national identification number while interacting with trustly Iframe for selectAccount method.