### PR TITLE
Added Credit method

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,7 +40,19 @@ export const deposit: MethodInterface = {
     ],
     requiredFields: ['NotificationURL', 'EndUserID', 'MessageID', 'Currency']
 }
-
+export const credit: MethodInterface = {
+    method: 'credit',
+    dataFields: ['Amount', 
+                 'Currency',
+                 'AccountID',
+                 'NotificationID',
+                 'EndUserID',
+                 'MessageID',
+                 'Timestamp'
+                ],
+    attributesFields: [],
+    requiredFields: ['OrderID', 'Amount', 'Currency']
+}
 export const refund: MethodInterface = {
     method: 'Refund',
     dataFields: ['OrderID', 'Amount', 'Currency'],


### PR DESCRIPTION
This is a method that Trustly will call on the merchant's system when the merchant's end-users account balance should be credited (increased).