### PR TITLE
fix(notification-response): Add 'FAILED' response

### DIFF
--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -97,15 +97,13 @@ export class Client {
         }
     }
 
-    _prepareNotificationResponse = function (notification) {
+    _prepareNotificationResponse = function (notification, status: 'OK' | 'FAILED' = 'OK') {
         let req = {
             result: {
                 signature: '',
                 uuid: notification.params.uuid,
                 method: notification.method,
-                data: {
-                    status: 'OK'
-                }
+                data: { status }
             },
             version: '1.1'
         }
@@ -122,7 +120,7 @@ export class Client {
         return req
     }
 
-    createNotificationResponse = async (notification, callback) => {
+    createNotificationResponse = async (notification, status: 'OK' | 'FAILED' = 'OK') => {
         await this.ready
 
         let lastNotification = null
@@ -154,7 +152,7 @@ export class Client {
                 throw new Error('Cant verify the response.')
             }
 
-            return this._prepareNotificationResponse(notification)
+            return this._prepareNotificationResponse(notification, status)
         } catch (err) {
             throw {
                 error: err,


### PR DESCRIPTION
On Trustly debit notification calls (when end-user's account should be
decreased), we have the opportunity to respond with 'FAILED' status
instead of 'OK'. This is needed in deposit cases where it's not possible
to decrease/take back the end-user's credits in the merchant system (in
my case, take back giftcard code).

 - Make it possible to set 'status' to 'FAILED'.
 - Remove unnecessary/unused callback.

https://trustly.com/en/developer/api/#/debit