### PR TITLE
feat(axios): Make it possible to supply axios config

### DIFF
--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -1,3 +1,5 @@
+import { AxiosRequestConfig } from 'axios';
+
 export type MethodInterface = {
     method: string
     dataFields: string[]
@@ -16,4 +18,5 @@ export type ConfigInterface = {
     specs?: {
         [key: string]: MethodInterface
     }
+    axiosRequestConfig?: Pick<AxiosRequestConfig, 'timeout'>
 }

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import { ConfigInterface } from '../Interfaces';
 import { accountPayout, approveWithdrawal, balance, charge, denyWithdrawal, deposit, refund, selectAccount, withdraw } from '../specs';
 import { serialize } from './trustlySerializeData';
@@ -11,6 +11,8 @@ export class Client {
     environment: 'development' | 'production' | 'prod' | 'p' = 'development'
     username: string = ''
     password: string = ''
+
+    axiosRequestConfig: AxiosRequestConfig | undefined
 
     privateKeyPath: string | undefined
     publicKeyPath: string
@@ -55,6 +57,7 @@ export class Client {
         this.password = config.password
         this.privateKeyPath = config.privateKeyPath
         this.privateKey = config.privateKey
+        this.axiosRequestConfig = config.axiosRequestConfig;
 
         this.ready = this._init()
     }
@@ -170,7 +173,8 @@ export class Client {
             url: this.endpoint,
             headers: { 'Content-Type': 'application/json; charset=utf-8' },
             data: reqParams,
-            timeout: 2000
+            timeout: 2000,
+            ...(this.axiosRequestConfig || {})
         })
             .then(({ data }) => {
                 this._lastResponse = data


### PR DESCRIPTION
We are getting a lot of timeouts from the Trustly API requests. 2000ms
timeout is a bit short for us it seems. This commit makes it possible to
configure the timeout value (and possibly other other properties) in the
axios request config.

Note that this PR doesn't contain any changes to the built files (`build/`),
just the source.